### PR TITLE
Small change so that resampling doesn't choke when using a Multinomial distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyo
 *.png
 /thinking.md
+*.DS_Store

--- a/models.py
+++ b/models.py
@@ -59,7 +59,12 @@ class HMM(ModelGibbsSampling):
     def resample_model(self):
         # resample obsparams
         for state, distn in enumerate(self.obs_distns):
-            distn.resample([s.data[s.stateseq == state] for s in self.states_list])
+            for s in self.states_list:
+                idx = np.where(s.stateseq == state)[0]
+                # print idx
+                # print s.data.shape
+                if len(idx) > 0:
+                    distn.resample(s.data[idx])
 
         # resample transitions
         self.trans_distn.resample([s.stateseq for s in self.states_list])


### PR DESCRIPTION
If a state hadn't yet been observed, then indexing "data" fails with an empty indexing array. Just added a quick check to make sure it doesn't happen.
