### PR TITLE
Fixing HMM log likelihood

### DIFF
--- a/models.py
+++ b/models.py
@@ -157,7 +157,7 @@ class HMM(ModelGibbsSampling):
 
         aBl = s.get_aBl(data)
         betal = s.messages_backwards(aBl)
-        return np.logaddexp.reduce(np.log(self.initial_distn.pi_0) + betal[0] + aBl[0])
+        return np.logaddexp.reduce(np.log(self.init_state_distn.pi_0) + betal[0] + aBl[0])
 
 
 class StickyHMM(HMM, ModelGibbsSampling):


### PR DESCRIPTION
I'm trying to use this library to build and run a normal boring no-frills HMM, for which I have a specific topology with specific transition probabilities that I already know. The first step of this is making HMM log likelihood not crash. Later steps will probably have to include adding something like Viterbi to get a self-consistent state path out, and documenting pyhsmm.internals.transitions.HDPHMMTransitions.**init** so I can tell where to put in the transition probabilities.

Where can I find the reference you used to name all the constructor arguments? What are e.g. the required alpha and gamma arguments to HDPHMMTransitions?

Is there a more appropriate transition distribution class to use when I already know exactly what state transition probabilities will be nonzero?
