### PR TITLE
Parallel resampling of observation distributions

### DIFF
--- a/models.py
+++ b/models.py
@@ -142,6 +142,8 @@ class HMM(ModelGibbsSampling, ModelEM):
 	    numtoresample = len(self.states_list)
 	elif numtoresample == 'engines':
 	    numtoresample = len(parallel.dv)
+	    if numtoresample > len(self.states_list):
+	      numtoresample = (self.states_list)
 	# push model and data to engines    
 	parallel.dv.push({'global_model': self},block=True)
 	### resample parameters locally

--- a/parallel.py
+++ b/parallel.py
@@ -59,9 +59,6 @@ def resample_obs_distns(state):
 @lbv.parallel(block=True)
 @interactive
 def resample_states(s):
-    global global_model
     s.resample()
     return s
-#    global_model.states_list[0].resample()
-#    return global_model.states_list[0]
   


### PR DESCRIPTION
Hi Matt,
I have created a resample_model_parallel2 function which resamples the observation distributions in parrallel. This was at the cost of pushing the model into the engines an additional time. However, on my test this had very minor overload. I have added code to parallel.py .. that was easy!!! given the code you had in there already.

In my initial test with Nmax = 100 the execution time came down to half :)

i did not see a way to parallelise the sampling of the trans_dist but let me know if you think it is possible  I can work on it. resampling of the initial state is super quick anyways so no  point in speeding that up. 

Thanks a lot!

Inti
