### PR TITLE
when plotting high-dimensional Gaussians, use first two dims. Fixes #66

### DIFF
--- a/pyhsmm/models.py
+++ b/pyhsmm/models.py
@@ -20,6 +20,7 @@ from pyhsmm.internals import hmm_states, hsmm_states, hsmm_inb_states, \
 from pyhsmm.util.general import list_split
 from pyhsmm.util.profiling import line_profiled
 from pybasicbayes.util.stats import atleast_2d
+from pybasicbayes.distributions.gaussian import Gaussian
 
 
 ################
@@ -330,6 +331,11 @@ class _HMMBase(Model):
 
         artists = []
         for state, (o, w) in enumerate(zip(self.obs_distns,usages)):
+            if o.D > 2:
+                if isinstance(o, Gaussian):
+                    o = Gaussian(o.mu[:2], o.sigma[:2, :2])
+                else:
+                    warn("High-dimensional distribution may not plot correctly in 2D")
             artists.extend(
                 o.plot(
                     color=state_colors[state], label='%d' % state,


### PR DESCRIPTION
This matches up with how high-dimensional data is plotted.

It's a fairly simple-minded fix: only works for Gaussians, and doesn't allow the user to specify which dimensions (in #66 as a nice-to-have)