### PR TITLE
Include build dependencies with pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include pyhsmm *.pyx *.c *.h *.cpp
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "future"]


### PR DESCRIPTION
Running `setup.py` requires future library and prefers to have Cython. The pyproject.toml file specifies those build dependencies so they are installed before pip tries to run setup.py.